### PR TITLE
npd: Move to oci registry

### DIFF
--- a/products/monitoring/node-problem-detector/Chart.yaml
+++ b/products/monitoring/node-problem-detector/Chart.yaml
@@ -5,4 +5,4 @@ version: 1.0.1
 dependencies:
   - name: node-problem-detector
     version: 2.3.14
-    repository: https://charts.deliveryhero.io/
+    repository: oci://ghcr.io/deliveryhero/helm-charts


### PR DESCRIPTION
Helm registry doesn't seem to be updated anymore, current chart version is 2.3.20