### PR TITLE
[codex] Migrate Velero PVC backup labels

### DIFF
--- a/products/connectivity/adguard/values.yaml
+++ b/products/connectivity/adguard/values.yaml
@@ -51,6 +51,8 @@ gatus-monitor:
 adguard:
   global:
     persistence:
+      labels:
+        backup.velero.io/include: "true"
       size: 3Gi
 
   primary:
@@ -88,9 +90,6 @@ adguard:
             kind: HTTPRouteFilter
             name: credential-injection
   secondary:
-    persistence:
-      labels:
-        feddema.dev/backup: "false"
     resources:
       requests:
         cpu: 50m

--- a/products/home/mealie/Chart.lock
+++ b/products/home/mealie/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mealie
+  repository: oci://ghcr.io/k8s-at-our-homes/helm-charts
+  version: 1.7.0
+digest: sha256:e9c259b38022f48f16861cff46feb64132df4376a70b8326a06a9186527e251e
+generated: "2026-04-04T20:33:54.110933+02:00"

--- a/products/home/mealie/Chart.yaml
+++ b/products/home/mealie/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.8
 
 dependencies:
   - name: mealie
-    version: 1.6.0
+    version: 1.7.0
     repository: oci://ghcr.io/k8s-at-our-homes/helm-charts

--- a/products/home/mealie/values.yaml
+++ b/products/home/mealie/values.yaml
@@ -1,4 +1,8 @@
 mealie:
+  persistence:
+    labels:
+      backup.velero.io/include: "true"
+
   ingress:
     enabled: false
 

--- a/products/media/media-server/templates/pvc.yaml
+++ b/products/media/media-server/templates/pvc.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "common.fullname" . }}-media
   labels:
-    feddema.dev/backup: "false"
     {{- include "common.labels" . | nindent 4 }}
 spec:
   storageClassName: {{ .Values.persistence.storageClass }}

--- a/products/storage/velero/templates/resource-policy.yaml
+++ b/products/storage/velero/templates/resource-policy.yaml
@@ -8,11 +8,6 @@ data:
     volumePolicies:
       - conditions:
           pvcLabels:
-            feddema.dev/backup: "false"
-        action:
-          type: skip
-      - conditions:
-          pvcLabels:
             cnpg.io/pvcRole: "PG_DATA"
         action:
           type: skip

--- a/products/storage/velero/values.yaml
+++ b/products/storage/velero/values.yaml
@@ -63,14 +63,9 @@ velero:
         ttl: "72h"
         storageLocation: default
         snapshotMoveData: true
-        includedNamespaces:
-        - adguard
-        - home-assistant
-        - immich
-        - media-server
-        - nextcloud
-        - mealie
-        - zigbee2mqtt
+        labelSelector:
+          matchLabels:
+            backup.velero.io/include: "true"
         resourcePolicy:
           kind: configmap
           name: resource-policy


### PR DESCRIPTION
## What changed

This updates the Velero PVC backup selection flow to rely on the `backup.velero.io/include` label on application PVCs.

It also upgrades the Mealie dependency chart to `1.7.0`, which now supports native PVC labels, and removes the old `feddema.dev/backup: "false"` opt-out path.

## Why

The Velero schedule now selects PVCs by label, so the product charts need to render the correct PVC labels directly.

## Impact

Applications covered by the updated chart values can now participate in Velero backups through the shared label-based selection model.

The old false-label skip rule is removed from Velero resource policy; only the CNPG `cnpg.io/pvcRole=PG_DATA` skip rule remains.

## Validation

Rendered and checked with Helm:

- `helm template adguard ./products/connectivity/adguard`
- `helm template media-server ./products/media/media-server`
- `helm template mealie ./products/home/mealie`
- Additional Helm render checks were also run earlier for Home Assistant, Immich, Nextcloud, Zigbee2MQTT, Jellyfin, Jellyseerr, Prowlarr, Radarr, Sabnzbd, and Sonarr to confirm the PVC label migration.
