### PR TITLE
[codex] Increase Velero backup frequency to every 4 hours

### DIFF
--- a/products/storage/velero/values.yaml
+++ b/products/storage/velero/values.yaml
@@ -58,7 +58,7 @@ velero:
       - --node-agent-configmap=velero-node-agent-config
   schedules:
     backup:
-      schedule: "23 3 * * *"
+      schedule: "23 */4 * * *"
       template:
         ttl: "72h"
         storageLocation: default


### PR DESCRIPTION
## What changed
- updated the Velero backup schedule from once per day to every 4 hours
- changed the cron expression from `23 3 * * *` to `23 */4 * * *`

## Why
- increases backup frequency so recovery points are no more than 4 hours old

## Impact
- Velero backup jobs will run at `00:23`, `04:23`, `08:23`, `12:23`, `16:23`, and `20:23`
- backup retention remains unchanged at `72h`

## Validation
- reviewed the config diff in `products/storage/velero/values.yaml`
