### PR TITLE
Fix Argo CD MCP container command

### DIFF
--- a/products/core/argo-cd/templates/argocd-mcp/deployment.yaml
+++ b/products/core/argo-cd/templates/argocd-mcp/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         - name: argocd-mcp-server
           image: {{ .Values.argocdMcp.image.repository }}:{{ .Values.argocdMcp.image.tag }}
           imagePullPolicy: {{ .Values.argocdMcp.image.pullPolicy }}
+          command:
+            - node
+            - dist/index.js
           args:
             - http
             - --port


### PR DESCRIPTION
## Summary
- set an explicit container command for the Argo CD MCP image
- keep `http --port 3000` as args so Kubernetes does not replace image `CMD`
- fix pod startup failure where Node tried to load `/app/http`

## Verification
- `helm template argo-cd products/core/argo-cd --namespace argocd`

## Context
The upstream image defines `CMD ["node", "dist/index.js", "http"]`. With only Kubernetes `args`, the container started as `node http --port 3000`, which caused `MODULE_NOT_FOUND` for `/app/http`.
