### PR TITLE
[codex] use velero pvc backup labels

### DIFF
--- a/products/home/home-assistant/values.yaml
+++ b/products/home/home-assistant/values.yaml
@@ -31,6 +31,8 @@ home-assistant:
 
   persistence:
     size: 10Gi
+    labels:
+      backup.velero.io/include: "true"
 
   route:
     enabled: true

--- a/products/home/immich/values.yaml
+++ b/products/home/immich/values.yaml
@@ -10,6 +10,8 @@ immich:
     size: 200Gi
     storageClass: 'ceph-file-nvme-2'
     accessMode: ReadWriteMany
+    labels:
+      backup.velero.io/include: "true"
 
   ingress:
     enabled: false

--- a/products/iot/zigbee2mqtt/values.yaml
+++ b/products/iot/zigbee2mqtt/values.yaml
@@ -37,7 +37,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true

--- a/products/media/jellyfin/values.yaml
+++ b/products/media/jellyfin/values.yaml
@@ -31,7 +31,7 @@ image:
 persistence:
   size: 4Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true

--- a/products/media/jellyseerr/values.yaml
+++ b/products/media/jellyseerr/values.yaml
@@ -28,7 +28,7 @@ image:
 persistence:
   size: 1Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true

--- a/products/media/prowlarr/values.yaml
+++ b/products/media/prowlarr/values.yaml
@@ -25,7 +25,7 @@ image:
 persistence:
   size: 1Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true

--- a/products/media/radarr/values.yaml
+++ b/products/media/radarr/values.yaml
@@ -26,7 +26,7 @@ image:
 persistence:
   size: 1Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true

--- a/products/media/sabnzbd/values.yaml
+++ b/products/media/sabnzbd/values.yaml
@@ -26,7 +26,7 @@ image:
 persistence:
   size: 1Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true

--- a/products/media/sonarr/values.yaml
+++ b/products/media/sonarr/values.yaml
@@ -26,7 +26,7 @@ image:
 persistence:
   size: 5Gi
   labels:
-    feddema.dev/backup: "true"
+    backup.velero.io/include: "true"
 
 route:
   enabled: true


### PR DESCRIPTION
## What changed
- replaced `feddema.dev/backup: "true"` with `backup.velero.io/include: "true"` on PVC labels for Zigbee2MQTT, Jellyfin, Jellyseerr, Prowlarr, Radarr, Sabnzbd, and Sonarr
- added `backup.velero.io/include: "true"` to the Home Assistant main persistence PVC
- added `backup.velero.io/include: "true"` to the Immich library persistence PVC

## Why
Velero backup selection should use the `backup.velero.io/include` label consistently across application PVCs.

## Impact
PVCs for these apps can now be targeted consistently by Velero using one label key.

## Validation
- inspected git diff for 9 modified values files
- verified branch push succeeded
