### PR TITLE
[codex] Re-enable Nextcloud Redis in standalone mode

### DIFF
--- a/products/home/nextcloud/values.yaml
+++ b/products/home/nextcloud/values.yaml
@@ -72,7 +72,8 @@ nextcloud:
       passwordKey: postgres-password
 
   redis:
-    enabled: false
+    enabled: true
+    architecture: standalone
 
   cronjob:
     enabled: true


### PR DESCRIPTION
## What changed
- re-enable the embedded Redis dependency for Nextcloud
- switch the Redis subchart to `standalone` architecture instead of the default replication mode

## Why
Nextcloud stopped working after Redis was disabled. Re-enabling Redis restores the cache/session backend it expects, while using standalone mode keeps the footprint to a single Redis pod instead of the default 4-pod replicated setup.

## Impact
- Nextcloud regains its Redis backend
- Redis adds 1 pod after sync, not 4
- Redis is no longer highly available, which is acceptable for this homelab setup

## Validation
- inspected the vendored Nextcloud chart defaults to confirm the Redis subchart defaults to replication with 1 master and 3 replicas
- updated the local values override to enable Redis and force `architecture: standalone`

## Root cause
The local Nextcloud values had `redis.enabled: false`, which removed the Redis backend Nextcloud had previously relied on.