### PR TITLE
Fix Harbor image repository path mapping

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -115,6 +115,20 @@ jobs:
           echo "patch=${BASH_REMATCH[3]}" >> "${GITHUB_OUTPUT}"
           echo "major_minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> "${GITHUB_OUTPUT}"
 
+      - name: Derive target repository path
+        id: image_name
+        shell: bash
+        run: |
+          image_path="${{ matrix.image }}"
+          repository_path="${image_path#*/}"
+
+          if [[ -z "${repository_path}" || "${repository_path}" == "${image_path}" ]]; then
+            echo "Image path must include a top-level group directory: ${image_path}" >&2
+            exit 1
+          fi
+
+          echo "repository_path=${repository_path}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -136,7 +150,7 @@ jobs:
           FORCE_PUSH: ${{ inputs.force_push }}
         shell: bash
         run: |
-          image_ref="${HARBOR_REGISTRY}/${HARBOR_PROJECT}/${{ matrix.image }}:${{ steps.version.outputs.version }}"
+          image_ref="${HARBOR_REGISTRY}/${HARBOR_PROJECT}/${{ steps.image_name.outputs.repository_path }}:${{ steps.version.outputs.version }}"
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${FORCE_PUSH}" == "true" ]]; then
             echo "Force push enabled; skipping duplicate version check for ${image_ref}"
@@ -152,7 +166,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.HARBOR_REGISTRY }}/${{ env.HARBOR_PROJECT }}/${{ matrix.image }}
+          images: ${{ env.HARBOR_REGISTRY }}/${{ env.HARBOR_PROJECT }}/${{ steps.image_name.outputs.repository_path }}
           tags: |
             type=raw,value=${{ steps.version.outputs.version }},priority=900
             type=raw,value=${{ steps.version.outputs.major_minor }},priority=800

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -120,10 +120,15 @@ jobs:
         shell: bash
         run: |
           image_path="${{ matrix.image }}"
-          repository_path="${image_path#*/}"
 
-          if [[ -z "${repository_path}" || "${repository_path}" == "${image_path}" ]]; then
-            echo "Image path must include a top-level group directory: ${image_path}" >&2
+          if [[ "${image_path}" == */* ]]; then
+            repository_path="${image_path#*/}"
+          else
+            repository_path="${image_path}"
+          fi
+
+          if [[ -z "${repository_path}" ]]; then
+            echo "Image path must not be empty" >&2
             exit 1
           fi
 

--- a/images/README.md
+++ b/images/README.md
@@ -23,8 +23,13 @@ images/
 The pushed Harbor image name is:
 
 ```text
-<HARBOR_REGISTRY>/<HARBOR_PROJECT>/<path-under-images>
+<HARBOR_REGISTRY>/<HARBOR_PROJECT>/<path-under-images-after-the-first-directory>
 ```
+
+For example:
+
+- `images/argo-workflows/go` pushes to `harbor.feddema.dev/argo-workflows/go`
+- `images/argo-workflows/go-envtest` pushes to `harbor.feddema.dev/argo-workflows/go-envtest`
 
 Published tags include:
 

--- a/images/README.md
+++ b/images/README.md
@@ -20,14 +20,20 @@ images/
       version
 ```
 
-The pushed Harbor image name is:
+The pushed Harbor image name depends on the layout:
 
-```text
-<HARBOR_REGISTRY>/<HARBOR_PROJECT>/<path-under-images-after-the-first-directory>
-```
+- Root-level image (`images/<image-name>/`): the full path is used as-is.
+  ```text
+  <HARBOR_REGISTRY>/<HARBOR_PROJECT>/<image-name>
+  ```
+- Grouped image (`images/<group>/<image-name>/`): the top-level group directory is stripped.
+  ```text
+  <HARBOR_REGISTRY>/<HARBOR_PROJECT>/<image-name>
+  ```
 
 For example:
 
+- `images/my-image` pushes to `harbor.feddema.dev/argo-workflows/my-image`
 - `images/argo-workflows/go` pushes to `harbor.feddema.dev/argo-workflows/go`
 - `images/argo-workflows/go-envtest` pushes to `harbor.feddema.dev/argo-workflows/go-envtest`
 


### PR DESCRIPTION
## Summary
- strip the top-level grouping directory from image paths before generating Harbor repository names
- push `images/argo-workflows/<name>` to `harbor.feddema.dev/argo-workflows/<name>` instead of duplicating the project path
- document the corrected mapping in the images README

## Why
The merged workflow was trying to push image names such as `harbor.feddema.dev/argo-workflows/argo-workflows/go`, which likely mapped to a repository path the Harbor credentials were not authorized to push to.

## Testing
- workflow YAML parses successfully locally
- verified local path mapping for `go`, `go-envtest`, and `helm-test`