### PR TITLE
[codex] Fix Harbor HA registry configuration

### DIFF
--- a/products/storage/harbor/Chart.lock
+++ b/products/storage/harbor/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: harbor
+  repository: https://helm.goharbor.io
+  version: 1.18.3
+- name: redis-ha
+  repository: https://dandydeveloper.github.io/charts
+  version: 4.35.10
+digest: sha256:f74d02da6593b940a87c3525e0442f3e2ceefe5e4ad3e07da51d33ae931362ac
+generated: "2026-04-28T20:08:21.650529+02:00"

--- a/products/storage/harbor/Chart.lock
+++ b/products/storage/harbor/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: harbor
-  repository: https://helm.goharbor.io
-  version: 1.18.3
-- name: redis-ha
-  repository: https://dandydeveloper.github.io/charts
-  version: 4.35.10
-digest: sha256:f74d02da6593b940a87c3525e0442f3e2ceefe5e4ad3e07da51d33ae931362ac
-generated: "2026-04-28T20:08:21.650529+02:00"

--- a/products/storage/harbor/Chart.yaml
+++ b/products/storage/harbor/Chart.yaml
@@ -6,3 +6,6 @@ dependencies:
   - name: harbor
     version: 1.18.3
     repository: https://helm.goharbor.io
+  - name: redis-ha
+    version: 4.35.10
+    repository: https://dandydeveloper.github.io/charts

--- a/products/storage/harbor/values.yaml
+++ b/products/storage/harbor/values.yaml
@@ -25,8 +25,6 @@ harbor:
   persistence:
     enabled: true
     persistentVolumeClaim:
-      redis:
-        size: 1Gi
       trivy:
         size: 5Gi
     imageChartStorage:
@@ -57,6 +55,13 @@ harbor:
     nodeSelector:
       kubernetes.io/arch: amd64
     replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            component: portal
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
@@ -67,6 +72,13 @@ harbor:
     nodeSelector:
       kubernetes.io/arch: amd64
     replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            component: core
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
@@ -78,6 +90,13 @@ harbor:
     nodeSelector:
       kubernetes.io/arch: amd64
     replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            component: jobservice
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
@@ -87,7 +106,14 @@ harbor:
     existingSecret: "harbor-credentials"
 
   registry:
-    replicas: 2
+    replicas: 1
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            component: registry
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
@@ -117,16 +143,42 @@ harbor:
       existingSecret: harbor-credentials
 
   redis:
-    type: internal
-    internal:
-      nodeSelector:
-        kubernetes.io/arch: amd64
+    type: external
+    external:
+      addr: harbor-redis-ha-haproxy:6379
 
   exporter:
     nodeSelector:
       kubernetes.io/arch: amd64
     replicas: 2
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            component: exporter
     podDisruptionBudget:
       enabled: true
       minAvailable: 1
     revisionHistoryLimit: 0
+
+redis-ha:
+  replicas: 3
+  haproxy:
+    enabled: true
+    replicas: 3
+  hardAntiAffinity: true
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 40m
+      memory: 64Mi
+  sentinel:
+    resources:
+      limits:
+        memory: 128Mi
+      requests:
+        cpu: 40m
+        memory: 64Mi

--- a/products/storage/harbor/values.yaml
+++ b/products/storage/harbor/values.yaml
@@ -165,6 +165,8 @@ harbor:
 
 redis-ha:
   replicas: 3
+  persistentVolume:
+    size: 5Gi
   haproxy:
     enabled: true
     replicas: 3


### PR DESCRIPTION
## What changed
- added the `redis-ha` chart dependency to the Harbor app
- switched Harbor from internal single-instance Redis to the HA Redis HAProxy service
- reduced Harbor registry replicas to `1` to isolate blob upload failures during pushes
- added `topologySpreadConstraints` for the multi-replica Harbor workloads
- added `Chart.lock` for the Harbor chart dependencies

## Why
Harbor was configured as HA in several places, but the Redis path was still single-instance and registry pushes were failing with `blob upload unknown to registry`. Scaling the registry down to one replica isolates the upload-state issue while keeping the rest of the Harbor stack aligned with HA deployment expectations.

## Impact
This should make the Harbor deployment more consistent and reduce the chance of cross-pod state issues during image pushes. The registry is intentionally single-replica for now until the upload path is proven stable.

## Validation
- `helm dependency build products/storage/harbor`
- `helm template harbor products/storage/harbor`
- YAML parse check for `products/storage/harbor/values.yaml`

## Notes
`kubectl` validation against the live cluster was not possible from this environment because the configured API server hostname could not be resolved locally.