### PR TITLE
[codex] increase ceph rgw memory

### DIFF
--- a/products/storage/rook-ceph/values.yaml
+++ b/products/storage/rook-ceph/values.yaml
@@ -545,9 +545,9 @@ rook-ceph-cluster:
           resources:
             requests:
               cpu: 10m
-              memory: 200Mi
+              memory: 300Mi
             limits:
-              memory: 500Mi
+              memory: 700Mi
           instances: 2
           opsLogSidecar:
             resources:


### PR DESCRIPTION
## What changed
Increase the Ceph RGW gateway memory request and limit in the Rook Ceph values.

- request: `200Mi` -> `300Mi`
- limit: `500Mi` -> `700Mi`

## Why
The RGW pod was hitting OOM pressure and needed a modest memory increase without changing other Ceph components.

## Impact
This gives the RGW gateway more headroom while keeping the change limited to the object store gateway configuration.

## Validation
- Reviewed the targeted diff in `products/storage/rook-ceph/values.yaml`
- No automated checks were run for this values-only change