### PR TITLE
[codex] tune ceph HDD alert thresholds

### DIFF
--- a/products/storage/rook-ceph/values.yaml
+++ b/products/storage/rook-ceph/values.yaml
@@ -220,6 +220,11 @@ rook-ceph-cluster:
         mon_data_avail_warn: '15'
       osd:
         osd_mclock_profile: "high_recovery_ops"
+      "class:hdd":
+        bdev_stalled_read_warn_lifetime: '600'
+        bdev_stalled_read_warn_threshold: '5'
+        bluestore_slow_ops_warn_lifetime: '600'
+        bluestore_slow_ops_warn_threshold: '10'
       mgr:
         mgr/dashboard/standby_behaviour: 'error'
         mgr/dashboard/FEATURE_TOGGLE_NFS: 'false'


### PR DESCRIPTION
## What changed
This updates the Rook Ceph GitOps values to apply less sensitive BlueStore warning thresholds only to `class:hdd` OSDs.

## Why
The cluster reports `BLUESTORE_SLOW_OP_ALERT` and `DB_DEVICE_STALLED_READ_ALERT` on HDD-backed OSDs, but these warnings are not harmful for the current workload. Scoping the tuning to HDDs keeps NVMe-backed OSDs on default sensitivity.

## Impact
Ceph will continue to emit these alerts, but only after a higher threshold on HDD OSDs:
- `bdev_stalled_read_warn_lifetime = 600`
- `bdev_stalled_read_warn_threshold = 5`
- `bluestore_slow_ops_warn_lifetime = 600`
- `bluestore_slow_ops_warn_threshold = 10`

## Validation
- Rendered the Helm chart locally after fetching dependencies.
- Confirmed the generated `CephCluster` manifest contains:
  - `cephConfig.class:hdd.bdev_stalled_read_warn_lifetime`
  - `cephConfig.class:hdd.bdev_stalled_read_warn_threshold`
  - `cephConfig.class:hdd.bluestore_slow_ops_warn_lifetime`
  - `cephConfig.class:hdd.bluestore_slow_ops_warn_threshold`

## Notes
This PR intentionally excludes unrelated local changes in `talos/*` and excludes the generated `products/storage/rook-ceph/Chart.lock` file.