### PR TITLE
Enable HTTP/3 for Envoy Gateway

### DIFF
--- a/products/connectivity/envoy-gateway/templates/client-traffic-policy.yaml
+++ b/products/connectivity/envoy-gateway/templates/client-traffic-policy.yaml
@@ -9,6 +9,7 @@ spec:
       kind: Gateway
       name: envoy-gateway-{{ $name }}
     {{- end }}
+  http3: {}
   path:
     escapedSlashesAction: KeepUnchanged
   tls:


### PR DESCRIPTION
## Summary
- enable HTTP/3 on Envoy Gateway via ClientTrafficPolicy
- keep the change scoped to the shared gateway policy

## Validation
- confirmed the live cluster currently exposes only 80/TCP and 443/TCP on the generated Envoy LoadBalancer services
- confirmed Cilium LB IPAM and BGP resources are present and compatible with mixed-protocol LoadBalancer services
- live cluster has not been synced with this change yet