### PR TITLE
[codex] allow kubechecks to reach Argo CD repo-server

### DIFF
--- a/products/core/argo-cd/templates/networkpolicy-kubechecks-repo-server.yaml
+++ b/products/core/argo-cd/templates/networkpolicy-kubechecks-repo-server.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-repo-server-allow-kubechecks
+  namespace: argocd
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kubechecks
+      ports:
+        - port: repo-server
+          protocol: TCP


### PR DESCRIPTION
## What changed
Add a supplemental `NetworkPolicy` in the Argo CD product chart to allow ingress to the Argo CD repo-server from the `kubechecks` namespace.

## Why
After the move to the `argo-cd` Helm chart `10.0.1`, kubechecks could no longer reach the repo-server. The upstream chart now emits a restrictive repo-server `NetworkPolicy`, so kubechecks needs an explicit additional allow rule.

## Impact
This restores kubechecks access to Argo CD's repo-server without broadening access to the rest of the `argocd` namespace. The policy targets only pods labeled `app.kubernetes.io/name: argocd-repo-server` and only opens the `repo-server` port from the `kubechecks` namespace.

## Validation
- Reviewed the Argo CD product chart values and confirmed no local network policy override existed.
- Confirmed the chart dependency is `argo-cd` `10.0.1`.
- Attempted local Helm render verification, but dependency fetch was blocked in the sandbox until push/PR work; no full rendered validation was completed in this session.
