### PR TITLE
Disable kubeconform in kubechecks

### DIFF
--- a/products/core/kubechecks/values.yaml
+++ b/products/core/kubechecks/values.yaml
@@ -27,6 +27,7 @@ kubechecks:
       KUBECHECKS_ARGOCD_API_PLAINTEXT: 'true'
       KUBECHECKS_ARGOCD_API_SERVER_ADDR: argocd-server.argocd
       KUBECHECKS_ARGOCD_SEND_FULL_REPOSITORY:  'true'
+      KUBECHECKS_ENABLE_KUBECONFORM: 'false'
       KUBECHECKS_SCHEMAS_LOCATION: https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json # Kubeconform schemas
       KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE: delete
       KUBECHECKS_MAX_CONCURRENT_CHECKS: '10'


### PR DESCRIPTION
## What changed
- disabled kubeconform in the kubechecks product config by setting `KUBECHECKS_ENABLE_KUBECONFORM` to `false`

## Why
- kubechecks enables kubeconform by default upstream
- this repo wanted kubeconform disabled for kubechecks specifically

## Impact
- kubechecks should stop running kubeconform checks for PRs handled by this instance

## Validation
- confirmed the upstream-supported env var is `KUBECHECKS_ENABLE_KUBECONFORM`
- attempted local `helm template` verification, but this chart currently cannot render in this checkout without first fetching missing Helm dependencies