### PR TITLE
chore: ignore Chart.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ fabric.properties
 ### Helm ###
 # Chart dependencies
 **/charts/*.tgz
+**/Chart.lock
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider


### PR DESCRIPTION
## Summary
- Ignore all Helm Chart.lock files via .gitignore