### PR TITLE
feat(tuppr): split Talos upgrades by zone

### DIFF
--- a/products/core/tuppr/templates/kubernetes-upgrade.yaml
+++ b/products/core/tuppr/templates/kubernetes-upgrade.yaml
@@ -4,8 +4,7 @@ metadata:
   name: gerador
 spec:
   kubernetes:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.3
+    version: {{ .Values.kubernetes.image.tag }}
   healthChecks:
     - apiVersion: ceph.rook.io/v1
       kind: CephCluster

--- a/products/core/tuppr/templates/talos-upgrade.yaml
+++ b/products/core/tuppr/templates/talos-upgrade.yaml
@@ -1,12 +1,16 @@
+{{- range $zone := .Values.talosUpgrade.zones }}
+---
 apiVersion: tuppr.home-operations.com/v1alpha1
 kind: TalosUpgrade
 metadata:
-  name: gerador
+  name: gerador-{{ $zone }}
 spec:
+  nodeSelector:
+    matchLabels:
+      topology.kubernetes.io/zone: {{ $zone | quote }}
   parallelism: 1
   talos:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.13.8
+    version: {{ $.Values.talos.image.tag }}
   policy:
     waitForVolumeDetach: true
   healthChecks:
@@ -18,4 +22,4 @@ spec:
       kind: Node
       expr: status.conditions.filter(c, c.type == "Ready").all(c, c.status == "True")
       timeout: 10m0s
-
+{{- end }}

--- a/products/core/tuppr/values.yaml
+++ b/products/core/tuppr/values.yaml
@@ -1,3 +1,20 @@
+talosUpgrade:
+  zones:
+    - hortek
+    - kashaylan
+    - korris
+    - tasuq
+
+talos:
+  image:
+    repository: ghcr.io/siderolabs/installer
+    tag: v1.13.8
+
+kubernetes:
+  image:
+    repository: ghcr.io/siderolabs/kubelet
+    tag: v1.36.3
+
 tuppr:
   monitoring:
     serviceMonitor:
@@ -16,4 +33,3 @@ tuppr:
 
   controller:
     logLevel: info
-


### PR DESCRIPTION
Talos upgrades currently target every node from a single resource. Split them by topology zone so each zone can be independently managed while retaining sequential node upgrades.

- Render one `TalosUpgrade` for each configured zone: hortek, kashaylan, korris, and tasuq.
- Move Talos and Kubernetes installer repository/tag references into chart values, and render the upgrade versions from those tags.
- Preserve the existing volume-detach policy and health checks.