### PR TITLE
fix(rgw): allow unsigned Content-Type

### DIFF
--- a/products/storage/rook-ceph/values.yaml
+++ b/products/storage/rook-ceph/values.yaml
@@ -276,6 +276,8 @@ rook-ceph-cluster:
         debug_rados: '0/5'
         debug_rbd: '0/5'
         debug_rgw: '0/5'
+        # Required because Loki and Thanos do not sign Content-Type in SigV4 requests.
+        rgw_sigv4_insecure: 'true'
       osd:
         osd_mclock_profile: "high_recovery_ops"
         osd_op_complaint_time: "60"


### PR DESCRIPTION
Ceph 20.2.4 rejects Loki and Thanos S3 uploads because their SigV4 requests omit `Content-Type` from the signed headers.

Enable RGW's `rgw_sigv4_insecure` compatibility setting so those object uploads authenticate successfully. This is a targeted workaround for stricter RGW signature validation.