### PR TITLE
feat: add homelab devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,64 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+ARG TARGETARCH
+# renovate: datasource=github-releases depName=mikefarah/yq
+ARG YQ_VERSION=v4.53.6
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=v1.36.4
+# renovate: datasource=github-releases depName=argoproj/argo-cd
+ARG ARGOCD_VERSION=v3.5.1
+# renovate: datasource=github-releases depName=siderolabs/talos
+ARG TALOS_VERSION=v1.13.9
+# renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VERSION=v4.2.4
+# renovate: datasource=github-releases depName=bitnami-labs/sealed-secrets
+ARG KUBESEAL_VERSION=v0.39.1
+# renovate: datasource=github-releases depName=ahmetb/kubectx
+ARG KUBENS_VERSION=v0.11.0
+# renovate: datasource=github-releases depName=stern/stern
+ARG STERN_VERSION=v1.34.0
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates curl jq \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN case "${TARGETARCH}" in \
+        amd64) arch="amd64"; kubectx_arch="x86_64" ;; \
+        arm64) arch="arm64"; kubectx_arch="arm64" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && temp_dir="$(mktemp -d)" \
+    && curl --fail --location --silent --show-error \
+        --output /usr/local/bin/yq \
+        "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${arch}" \
+    && curl --fail --location --silent --show-error \
+        --output /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+    && curl --fail --location --silent --show-error \
+        --output /usr/local/bin/argocd \
+        "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-${arch}" \
+    && curl --fail --location --silent --show-error \
+        --output /usr/local/bin/talosctl \
+        "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-${arch}" \
+    && curl --fail --location --silent --show-error \
+        --output "${temp_dir}/helm.tar.gz" \
+        "https://get.helm.sh/helm-${HELM_VERSION}-linux-${arch}.tar.gz" \
+    && tar --extract --gzip --file "${temp_dir}/helm.tar.gz" --directory "${temp_dir}" \
+    && install "${temp_dir}/linux-${arch}/helm" /usr/local/bin/helm \
+    && curl --fail --location --silent --show-error \
+        --output "${temp_dir}/kubeseal.tar.gz" \
+        "https://github.com/bitnami-labs/sealed-secrets/releases/download/${KUBESEAL_VERSION}/kubeseal-${KUBESEAL_VERSION#v}-linux-${arch}.tar.gz" \
+    && tar --extract --gzip --file "${temp_dir}/kubeseal.tar.gz" --directory "${temp_dir}" \
+    && install "${temp_dir}/kubeseal" /usr/local/bin/kubeseal \
+    && curl --fail --location --silent --show-error \
+        --output "${temp_dir}/kubens.tar.gz" \
+        "https://github.com/ahmetb/kubectx/releases/download/${KUBENS_VERSION}/kubens_${KUBENS_VERSION}_linux_${kubectx_arch}.tar.gz" \
+    && tar --extract --gzip --file "${temp_dir}/kubens.tar.gz" --directory "${temp_dir}" \
+    && install "${temp_dir}/kubens" /usr/local/bin/kubens \
+    && curl --fail --location --silent --show-error \
+        --output "${temp_dir}/stern.tar.gz" \
+        "https://github.com/stern/stern/releases/download/${STERN_VERSION}/stern_${STERN_VERSION#v}_linux_${arch}.tar.gz" \
+    && tar --extract --gzip --file "${temp_dir}/stern.tar.gz" --directory "${temp_dir}" \
+    && install "${temp_dir}/stern" /usr/local/bin/stern \
+    && rm -rf "${temp_dir}" \
+    && chmod +x /usr/local/bin/yq /usr/local/bin/kubectl /usr/local/bin/argocd /usr/local/bin/talosctl

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,26 @@
+# Devcontainer credentials
+
+The devcontainer uses dedicated read-only Kubernetes and Talos credentials from
+`~/.config/homelab-devcontainer`. It never mounts the administrator kubeconfig or
+Talos configuration.
+
+After Argo CD has synced the `devcontainer-users` app, create or rotate the
+credentials from a trusted host shell that has administrator `kubectl` and
+`talosctl` configuration:
+
+```shell
+TALOSCONFIG=~/.talos/config ./.devcontainer/bootstrap-readonly-credentials.sh mba-floris-devcontainer
+```
+
+The Argo CD app creates the `homelab-devcontainer` namespace, a Kubernetes
+service account for each `users` entry in
+`products/ai/devcontainer-users/values.yaml`. Every configured user is bound to
+the built-in `view` role and the same selected cluster-scoped read permissions.
+The script creates a Talos client certificate with the `os:reader` role and
+writes the credential files.
+
+To revoke access permanently, remove the user from
+`products/ai/devcontainer-users/values.yaml` and allow Argo CD to prune its
+ServiceAccount and token Secret. Deleting the token Secret directly only rotates
+the token because Argo CD recreates the Secret; rerun the bootstrap script to
+use the replacement credential.

--- a/.devcontainer/bootstrap-readonly-credentials.sh
+++ b/.devcontainer/bootstrap-readonly-credentials.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly credentials_dir="${DEVCONTAINER_CREDENTIALS_DIR:-"${HOME}/.config/homelab-devcontainer"}"
+readonly service_account_namespace="homelab-devcontainer"
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <devcontainer-user>" >&2
+    exit 1
+fi
+
+readonly service_account_name="$1"
+readonly token_secret_name="${service_account_name}-token"
+
+if ! command -v kubectl >/dev/null; then
+    echo "kubectl is required to create the Kubernetes reader credentials." >&2
+    exit 1
+fi
+
+if ! command -v talosctl >/dev/null; then
+    echo "talosctl is required to create the Talos reader credentials." >&2
+    exit 1
+fi
+
+if [[ -z "${TALOSCONFIG:-}" ]]; then
+    echo "Set TALOSCONFIG to an administrator Talos configuration before running this script." >&2
+    exit 1
+fi
+
+if [[ ! -f "${TALOSCONFIG}" ]]; then
+    echo "TALOSCONFIG does not exist: ${TALOSCONFIG}" >&2
+    exit 1
+fi
+
+if ! kubectl get namespace "${service_account_namespace}" >/dev/null; then
+    echo "The ${service_account_namespace} namespace is not available. Wait for Argo CD to sync the devcontainer-users app." >&2
+    exit 1
+fi
+
+token=""
+for _ in $(seq 1 30); do
+    if token="$(kubectl --namespace "${service_account_namespace}" get secret "${token_secret_name}" --output jsonpath='{.data.token}' 2>/dev/null)" && [[ -n "${token}" ]]; then
+        break
+    fi
+    sleep 1
+done
+
+if [[ -z "${token}" ]]; then
+    echo "Timed out waiting for the service account token secret." >&2
+    exit 1
+fi
+
+if base64 --decode </dev/null >/dev/null 2>&1; then
+    token="$(printf '%s' "${token}" | base64 --decode)"
+else
+    token="$(printf '%s' "${token}" | base64 -D)"
+fi
+
+cluster_server="$(kubectl config view --minify --raw --output jsonpath='{.clusters[0].cluster.server}')"
+cluster_ca_data="$(kubectl config view --minify --raw --output jsonpath='{.clusters[0].cluster.certificate-authority-data}')"
+
+if [[ -z "${cluster_server}" || -z "${cluster_ca_data}" ]]; then
+    echo "The active kubeconfig context must include a server and embedded certificate authority data." >&2
+    exit 1
+fi
+
+umask 077
+mkdir -p "${credentials_dir}"
+
+cat > "${credentials_dir}/kubeconfig" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: gerador
+    cluster:
+      certificate-authority-data: ${cluster_ca_data}
+      server: ${cluster_server}
+contexts:
+  - name: ${service_account_name}
+    context:
+      cluster: gerador
+      namespace: default
+      user: ${service_account_name}
+current-context: ${service_account_name}
+users:
+  - name: ${service_account_name}
+    user:
+      token: ${token}
+EOF
+
+talosctl config new --roles=os:reader "${credentials_dir}/talosconfig"
+
+echo "Read-only Kubernetes and Talos credentials written to ${credentials_dir}."

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Homelab",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "KUBECONFIG": "/home/vscode/.config/homelab-devcontainer/kubeconfig",
+    "TALOSCONFIG": "/home/vscode/.config/homelab-devcontainer/talosconfig"
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.config/homelab-devcontainer,target=/home/vscode/.config/homelab-devcontainer,type=bind,readonly"
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,16 @@
       "matchPackageNames": ["ghcr.io/siderolabs/installer"],
       "separateMajorMinor": true,
       "separateMinorPatch": true
+    },
+    {
+      "description": "Group devcontainer CLI tool updates",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": [".devcontainer/Dockerfile"],
+      "groupName": "Devcontainer CLI tools",
+      "groupSlug": "devcontainer-cli-tools",
+      "separateMajorMinor": false,
+      "separateMinorPatch": false,
+      "separateMultipleMajor": false
     }
   ],
   "customManagers": [
@@ -47,6 +57,17 @@
         "name:\\s*(?<depName>ghcr\\.io/zapier/kubechecks)\\s*tag:\\s*(?<currentValue>v?[\\d\\.]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Manage pinned devcontainer CLI versions",
+      "managerFilePatterns": [
+        "/^\\.devcontainer\\/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>github-releases) depName=(?<depName>[^\\s]+)\\s+ARG [A-Z_]+_VERSION=(?<currentValue>[^\\s]+)"
+      ],
+      "versioningTemplate": "semver"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,17 @@ Network and edge:
 - AdGuard
 
 Useful CLIs:
-- `kubectl`
-- `talosctl`
+- `argocd`
 - `helm`
+- `jq`
+- `kubectl`
+- `kubens`
 - `kubeseal`
+- `stern`
+- `talosctl`
 - `yq`
+
+The devcontainer installs all of these CLIs.
 
 ## MCP Servers Available To Copilot
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ Most operations in this repo assume:
 - A working kubeconfig for the `gerador` cluster
 - A working Talos config for the same cluster
 - These CLIs installed locally:
+  - `argocd`
   - `helm`
+  - `jq`
   - `kubectl`
+  - `kubens`
+  - `stern`
   - `talosctl`
   - `kubeseal`
   - `yq`

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,6 +37,10 @@ products:
       deploy: true
       autoSync: true
   ai:
+    devcontainerUsers:
+      deploy: true
+      autoSync: true
+      namespace: homelab-devcontainer
     grafanaMcpServer:
       deploy: true
       autoSync: true

--- a/products/ai/devcontainer-users/Chart.yaml
+++ b/products/ai/devcontainer-users/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: devcontainer-users
+description: Read-only credentials for homelab development container users
+version: 1.0.0

--- a/products/ai/devcontainer-users/templates/namespace.yaml
+++ b/products/ai/devcontainer-users/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: devcontainer-users

--- a/products/ai/devcontainer-users/templates/read-only-rbac.yaml
+++ b/products/ai/devcontainer-users/templates/read-only-rbac.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: homelab-devcontainer-cluster-reader
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+      - csinodes
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homelab-devcontainer-users-reader-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+{{- range $user := .Values.users }}
+  - kind: ServiceAccount
+    name: {{ $user }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: homelab-devcontainer-users-reader-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: homelab-devcontainer-cluster-reader
+subjects:
+{{- range $user := .Values.users }}
+  - kind: ServiceAccount
+    name: {{ $user }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+---
+{{- range $user := .Values.users }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $user }}
+  namespace: {{ $.Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $user }}-token
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ $user }}
+type: kubernetes.io/service-account-token
+---
+{{- end }}

--- a/products/ai/devcontainer-users/values.yaml
+++ b/products/ai/devcontainer-users/values.yaml
@@ -1,0 +1,3 @@
+# Each user receives the same read-only Kubernetes and Talos permissions.
+users:
+  - mba-floris-devcontainer


### PR DESCRIPTION
Adds a reproducible homelab development environment without exposing administrator cluster credentials.

- Installs pinned Kubernetes, Talos, Helm, Argo CD, Sealed Secrets, and log-management CLIs for AMD64 and ARM64.
- Lets Renovate update all devcontainer CLI versions in one grouped PR.
- Adds an Argo CD-managed `devcontainer-users` app that provisions value-driven, read-only Kubernetes identities.
- Generates a separate `os:reader` Talos configuration and mounts only generated reader credentials into the container.

Reader identities are declared in `products/ai/devcontainer-users/values.yaml`; remove an entry there to revoke it durably.