### PR TITLE
Improve Loki reliability safeguards

### DIFF
--- a/products/monitoring/loki/templates/alerts.yaml
+++ b/products/monitoring/loki/templates/alerts.yaml
@@ -1,0 +1,48 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: loki.rules
+spec:
+  groups:
+    - name: loki.rules
+      rules:
+        - alert: LokiRateLimitedIngestion
+          expr: sum(increase(loki_discarded_samples_total{namespace="loki",reason=~"rate_limited|per_stream_rate_limit"}[15m])) > 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Loki is discarding rate-limited log samples
+            description: Loki discarded {{ `{{ $value }}` }} log samples in the last 15 minutes because of ingestion rate limits.
+        - alert: LokiWritePathUnavailable
+          expr: sum(up{namespace="loki",job="loki/loki-distributor"}) < 2 or sum(up{namespace="loki",job="loki/loki-ingester"}) < 3
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Loki write path is unavailable
+            description: Loki has fewer healthy distributors or ingesters than its configured replica count.
+        - alert: LokiReadPathUnavailable
+          expr: sum(up{namespace="loki",job="loki/loki-query-frontend"}) < 2 or sum(up{namespace="loki",job="loki/loki-querier"}) < 2
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Loki read path is unavailable
+            description: Loki has fewer healthy query frontends or queriers than its configured replica count.
+        - alert: LokiCompactorStalled
+          expr: time() - max(loki_compactor_apply_retention_last_successful_run_timestamp_seconds{namespace="loki"}) > 21600
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Loki retention compactor is stalled
+            description: Loki has not completed a retention run for more than six hours.
+        - alert: LokiRetentionDeletionBacklog
+          expr: sum(loki_boltdb_shipper_retention_sweeper_marker_files_current{namespace="loki"}) > 0
+          for: 4h
+          labels:
+            severity: warning
+          annotations:
+            summary: Loki retention deletion backlog is growing
+            description: Loki has retention marker files awaiting deletion for more than four hours.

--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -22,7 +22,7 @@ loki:
     analytics:
       reporting_enabled: false
     ingester:
-      chunk_encoding: snappy
+      chunk_encoding: zstd
       wal:
         enabled: true
     pattern_ingester:
@@ -33,8 +33,8 @@ loki:
       allow_structured_metadata: true
       volume_enabled: true
       retention_period: 168h
-      ingestion_rate_mb: 4
-      ingestion_burst_size_mb: 8
+      ingestion_rate_mb: 6
+      ingestion_burst_size_mb: 12
       per_stream_rate_limit: 3MB
       per_stream_rate_limit_burst: 6MB
       max_global_streams_per_user: 5000
@@ -61,7 +61,14 @@ loki:
   test:
     enabled: false
   lokiCanary:
-    enabled: false
+    enabled: true
+    lokiurl: loki-distributor.loki.svc.cluster.local:3100
+    resources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi
   gateway:
     enabled: false
   write:
@@ -144,6 +151,10 @@ loki:
     replicas: 1
     persistence:
       enabled: true
+      storageClass: ceph-block-nvme-2
+      accessModes:
+        - ReadWriteOnce
+      size: 10Gi
     resources:
       limits:
         memory: 200Mi

--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -32,7 +32,7 @@ loki:
     limits_config:
       allow_structured_metadata: true
       volume_enabled: true
-      retention_period: 168h
+      retention_period: 72h
       ingestion_rate_mb: 6
       ingestion_burst_size_mb: 12
       per_stream_rate_limit: 3MB


### PR DESCRIPTION
Loki is discarding rate-limited samples during normal bursts, while its disabled canary leaves the write/query path without an end-to-end health signal.

- Raises the global ingestion rate and burst limits while retaining per-stream protection.
- Uses Zstd for newly written chunks, enables a resource-bounded canary through the distributor, and makes the compactor workspace storage explicit.
- Adds Loki-owned alerts for rate-limited ingestion, read/write availability, compactor stalling, and retention deletion backlog.

The compactor intentionally remains a long-running singleton StatefulSet: the upstream chart does not support using it as a compaction Job.