### PR TITLE
Fix Loki canary gateway routing

### DIFF
--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -62,7 +62,6 @@ loki:
     enabled: false
   lokiCanary:
     enabled: true
-    lokiurl: loki-distributor.loki.svc.cluster.local:3100
     resources:
       limits:
         memory: 64Mi
@@ -70,7 +69,13 @@ loki:
         cpu: 10m
         memory: 32Mi
   gateway:
-    enabled: false
+    enabled: true
+    resources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi
   write:
     replicas: 0
   read:


### PR DESCRIPTION
Loki Canary requires the WebSocket tail endpoint to verify that emitted logs can be queried. Routing it directly to the distributor causes the observed bad WebSocket handshake because the distributor only serves ingestion.

Enables the Loki gateway with bounded resources and restores the chart's gateway-based canary route, providing one endpoint for both push and tail requests.