### PR TITLE
Fix Loki gateway DNS resolver

### DIFF
--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -70,6 +70,8 @@ loki:
         memory: 32Mi
   gateway:
     enabled: true
+    nginxConfig:
+      resolver: 10.96.0.9
     resources:
       limits:
         memory: 64Mi


### PR DESCRIPTION
The Loki gateway could not start because the upstream chart defaults NGINX to resolve a `kube-dns` Service that this Talos cluster does not provide.

Configure the gateway to use the cluster DNS Service ClusterIP (`10.96.0.9`) directly. This removes the startup-time Service-name lookup while preserving runtime DNS resolution for gateway upstreams.