### PR TITLE
Fix Loki gateway DNS endpoint

### DIFF
--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -71,7 +71,7 @@ loki:
   gateway:
     enabled: true
     nginxConfig:
-      resolver: 10.96.0.9
+      resolver: 10.96.0.10
     resources:
       limits:
         memory: 64Mi


### PR DESCRIPTION
The Loki gateway starts successfully but cannot proxy canary traffic because `10.96.0.9` does not answer DNS queries in this cluster.

Use `10.96.0.10`, the working cluster DNS endpoint configured in gateway pods' `/etc/resolv.conf`, so NGINX can resolve the query frontend and distributor upstreams.