### PR TITLE
Reduce Loki gateway log volume

### DIFF
--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -70,6 +70,7 @@ loki:
         memory: 32Mi
   gateway:
     enabled: true
+    verboseLogging: false
     nginxConfig:
       resolver: 10.96.0.10
     resources:


### PR DESCRIPTION
The Loki gateway currently logs every successful canary and ingestion request, creating unnecessary log volume.

Disable successful-request access logs through the chart's `verboseLogging` setting. NGINX warnings and errors remain available for diagnosing gateway failures.