### PR TITLE
Reduce Loki component log volume

### DIFF
--- a/products/monitoring/loki/values.yaml
+++ b/products/monitoring/loki/values.yaml
@@ -25,6 +25,8 @@ loki:
       chunk_encoding: zstd
       wal:
         enabled: true
+    server:
+      log_level: warn
     pattern_ingester:
       enabled: true
     querier:


### PR DESCRIPTION
Loki components inherit the upstream `info` log level, which emits routine request and lifecycle messages across the distributed deployment.

Set the shared Loki server log level to `warn`. This applies to the write, read, query, index, and compaction components while retaining warning and error messages for operational diagnosis.