### PR TITLE
fix(kubechecks): suppress pre-upgrade warnings

### DIFF
--- a/products/core/kubechecks/values.yaml
+++ b/products/core/kubechecks/values.yaml
@@ -28,6 +28,7 @@ kubechecks:
       KUBECHECKS_ARGOCD_API_SERVER_ADDR: argocd-server.argocd
       KUBECHECKS_ARGOCD_SEND_FULL_REPOSITORY:  'true'
       KUBECHECKS_ENABLE_KUBECONFORM: 'false'
+      KUBECHECKS_ENABLE_PREUPGRADE: 'false'
       KUBECHECKS_SCHEMAS_LOCATION: https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json # Kubeconform schemas
       KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE: delete
       KUBECHECKS_MAX_CONCURRENT_CHECKS: '10'


### PR DESCRIPTION
Kubechecks produces warning reports on PRs from its pre-upgrade checker. Disable that checker so PR comments retain manifest-diff results without the recurring warnings.