### PR TITLE
fix(storage): enable CSI reclaim add-ons

### DIFF
--- a/products/storage/csi-addons/values.yaml
+++ b/products/storage/csi-addons/values.yaml
@@ -1,0 +1,8 @@
+csi-addons:
+  replicas: 2
+
+  config:
+    reclaimSpaceTimeout: 10m
+    maxConcurrentReconciles: 1
+    maxGroupPvcs: 1
+    schedulePrecedence: pvc

--- a/products/storage/rook-ceph/values.yaml
+++ b/products/storage/rook-ceph/values.yaml
@@ -28,6 +28,7 @@ ceph-csi-drivers:
     rbd:
       enabled: true
       name: rook-ceph.rbd.csi.ceph.com
+      deployCsiAddons: true
       snapshotPolicy: volumeGroupSnapshot
     cephfs:
       enabled: true


### PR DESCRIPTION
ReclaimSpaceJobs were failing cluster-wide because the RBD Driver explicitly disabled the CSI add-on endpoints they require.

Enable CSI add-ons for RBD and configure the add-on manager with two leader-elected replicas, a 10-minute reclaim timeout aligned to the job retry deadline, and conservative concurrency.