### PR TITLE
Schedule system workloads on control-plane nodes

### DIFF
--- a/products/connectivity/cilium/values.yaml
+++ b/products/connectivity/cilium/values.yaml
@@ -135,18 +135,9 @@ cilium:
       argocd.argoproj.io/sync-options: ServerSideApply=true
 
   operator:
-    tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-                - key: node-role.kubernetes.io/control-plane
-                  operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
+      node-role.kubernetes.io/control-plane: ""
     prometheus:
       metricsService: true
       serviceMonitor:

--- a/products/storage/rook-ceph/values.yaml
+++ b/products/storage/rook-ceph/values.yaml
@@ -319,6 +319,10 @@ rook-ceph-cluster:
 
     placement:
       mon:
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
         topologySpreadConstraints:
           - maxSkew: 1
             topologyKey: topology.kubernetes.io/zone
@@ -327,13 +331,13 @@ rook-ceph-cluster:
               matchLabels:
                 app: rook-ceph-mon
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
                   - key: node-role.kubernetes.io/control-plane
                     operator: Exists
-            - weight: 50
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
               preference:
                 matchExpressions:
                   - key: kubernetes.io/arch


### PR DESCRIPTION
Use the available control-plane capacity for lightweight system workloads instead of leaving those nodes reserved exclusively for control-plane components.

- Require Ceph MONs to run on control-plane nodes and tolerate their taint, while preserving zone spreading and preferring amd64.
- Pin the Cilium operator to control-plane nodes while retaining the upstream tolerations and pod anti-affinity.
- Talos CCM remains control-plane-only at two replicas.