### PR TITLE
Increase kube-apiserver memory request

### DIFF
--- a/talos/controlplane.yaml
+++ b/talos/controlplane.yaml
@@ -9,7 +9,7 @@ cluster:
     resources:
       requests:
         cpu: 700m
-        memory: 5Gi
+        memory: 7Gi
 
   controllerManager:
     extraArgs:


### PR DESCRIPTION
The kube-apiserver has exceeded its existing 5 GiB request on two control-plane nodes, with a seven-day peak near 7 GiB. Increase the request to 7 GiB so Kubernetes reserves the observed memory requirement and is less likely to overcommit control-plane nodes.

This changes only the request; it does not impose a memory limit.