### PR TITLE
Enable read-only cluster integrations in the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,11 @@ RUN apt-get update \
     && apt-get install --yes --no-install-recommends ca-certificates curl jq \
     && rm -rf /var/lib/apt/lists/*
 
+COPY .devcontainer/argocd /usr/local/bin/argocd
+
+RUN install -d --owner=vscode --group=vscode /home/vscode/.copilot \
+    && ln -s /home/vscode/.config/homelab-devcontainer/mcp-config.json /home/vscode/.copilot/mcp-config.json
+
 RUN case "${TARGETARCH}" in \
         amd64) arch="amd64"; kubectx_arch="x86_64" ;; \
         arm64) arch="arm64"; kubectx_arch="arm64" ;; \
@@ -35,7 +40,7 @@ RUN case "${TARGETARCH}" in \
         --output /usr/local/bin/kubectl \
         "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
     && curl --fail --location --silent --show-error \
-        --output /usr/local/bin/argocd \
+        --output /usr/local/bin/argocd-real \
         "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-${arch}" \
     && curl --fail --location --silent --show-error \
         --output /usr/local/bin/talosctl \
@@ -61,4 +66,4 @@ RUN case "${TARGETARCH}" in \
     && tar --extract --gzip --file "${temp_dir}/stern.tar.gz" --directory "${temp_dir}" \
     && install "${temp_dir}/stern" /usr/local/bin/stern \
     && rm -rf "${temp_dir}" \
-    && chmod +x /usr/local/bin/yq /usr/local/bin/kubectl /usr/local/bin/argocd /usr/local/bin/talosctl
+    && chmod +x /usr/local/bin/argocd /usr/local/bin/yq /usr/local/bin/kubectl /usr/local/bin/argocd-real /usr/local/bin/talosctl

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -4,23 +4,54 @@ The devcontainer uses dedicated read-only Kubernetes and Talos credentials from
 `~/.config/homelab-devcontainer`. It never mounts the administrator kubeconfig or
 Talos configuration.
 
-After Argo CD has synced the `devcontainer-users` app, create or rotate the
-credentials from a trusted host shell that has administrator `kubectl` and
-`talosctl` configuration:
+## Argo CD
+
+The `argocd` command runs in core mode using the mounted read-only Kubernetes
+credentials. This lets it inspect Argo CD Applications without an Argo CD API
+token:
+
+```shell
+argocd app list
+argocd app get <application>
+```
+
+Write operations, including application syncs, remain denied by Kubernetes RBAC.
+To authenticate to the Argo CD API directly, use
+`/usr/local/bin/argocd-real`.
+
+## Grafana MCP
+
+The credential bootstrap generates Copilot CLI configuration for the read-only
+Grafana MCP server. The devcontainer exposes it at
+`~/.copilot/mcp-config.json`, so Copilot discovers the server automatically:
+
+```shell
+copilot mcp get grafana
+```
+
+The API key is unique to the configured devcontainer user. Removing that user
+from `auth.clients` in `products/ai/grafana-mcp-server/values.yaml` revokes its
+Grafana MCP access after Argo CD syncs the change.
+
+## Credential bootstrap
+
+After Argo CD has synced the `devcontainer-users` and `grafana-mcp-server`
+apps, create or rotate the credentials from a trusted host shell that has
+administrator `kubectl` and `talosctl` configuration:
 
 ```shell
 TALOSCONFIG=~/.talos/config ./.devcontainer/bootstrap-readonly-credentials.sh mba-floris-devcontainer
 ```
 
-The Argo CD app creates the `homelab-devcontainer` namespace, a Kubernetes
+The Argo CD apps create the `homelab-devcontainer` namespace, a Kubernetes
 service account for each `users` entry in
 `products/ai/devcontainer-users/values.yaml`. Every configured user is bound to
 the built-in `view` role and the same selected cluster-scoped read permissions.
-The script creates a Talos client certificate with the `os:reader` role and
-writes the credential files.
+The Grafana MCP chart creates a matching API key for each `auth.clients` entry
+in `products/ai/grafana-mcp-server/values.yaml`. The script also creates a Talos
+client certificate with the `os:reader` role and writes the credential files.
 
-To revoke access permanently, remove the user from
-`products/ai/devcontainer-users/values.yaml` and allow Argo CD to prune its
-ServiceAccount and token Secret. Deleting the token Secret directly only rotates
-the token because Argo CD recreates the Secret; rerun the bootstrap script to
-use the replacement credential.
+To revoke all access permanently, remove the user from both product values
+files and allow Argo CD to reconcile the changes. Deleting the Kubernetes token
+Secret directly only rotates that token because Argo CD recreates the Secret;
+rerun the bootstrap script to use replacement credentials.

--- a/.devcontainer/argocd
+++ b/.devcontainer/argocd
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec /usr/local/bin/argocd-real --core "$@"

--- a/.devcontainer/bootstrap-readonly-credentials.sh
+++ b/.devcontainer/bootstrap-readonly-credentials.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 readonly credentials_dir="${DEVCONTAINER_CREDENTIALS_DIR:-"${HOME}/.config/homelab-devcontainer"}"
 readonly service_account_namespace="homelab-devcontainer"
+readonly grafana_mcp_namespace="grafana-mcp-server"
+readonly grafana_mcp_secret_name="grafana-mcp-bearer-auth-secret"
+readonly grafana_mcp_url="https://grafana.mcp.feddema.dev/mcp"
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <devcontainer-user>" >&2
@@ -51,10 +54,21 @@ if [[ -z "${token}" ]]; then
     exit 1
 fi
 
+grafana_mcp_key="$(
+    kubectl --namespace "${grafana_mcp_namespace}" get secret "${grafana_mcp_secret_name}" \
+        --output "jsonpath={.data.${service_account_name}}" 2>/dev/null
+)"
+if [[ -z "${grafana_mcp_key}" ]]; then
+    echo "No Grafana MCP credential exists for ${service_account_name}. Wait for Argo CD to sync the grafana-mcp-server app." >&2
+    exit 1
+fi
+
 if base64 --decode </dev/null >/dev/null 2>&1; then
     token="$(printf '%s' "${token}" | base64 --decode)"
+    grafana_mcp_key="$(printf '%s' "${grafana_mcp_key}" | base64 --decode)"
 else
     token="$(printf '%s' "${token}" | base64 -D)"
+    grafana_mcp_key="$(printf '%s' "${grafana_mcp_key}" | base64 -D)"
 fi
 
 cluster_server="$(kubectl config view --minify --raw --output jsonpath='{.clusters[0].cluster.server}')"
@@ -89,6 +103,21 @@ users:
       token: ${token}
 EOF
 
+cat > "${credentials_dir}/mcp-config.json" <<EOF
+{
+  "mcpServers": {
+    "grafana": {
+      "type": "http",
+      "url": "${grafana_mcp_url}",
+      "headers": {
+        "Authorization": "Bearer ${grafana_mcp_key}"
+      },
+      "tools": ["*"]
+    }
+  }
+}
+EOF
+
 talosctl config new --roles=os:reader "${credentials_dir}/talosconfig"
 
-echo "Read-only Kubernetes and Talos credentials written to ${credentials_dir}."
+echo "Read-only Kubernetes, Talos, and Grafana MCP credentials written to ${credentials_dir}."

--- a/products/ai/grafana-mcp-server/Chart.yaml
+++ b/products/ai/grafana-mcp-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grafana-mcp-server
-version: 1.0.16
+version: 1.0.17
 
 dependencies:
   - name: grafana-mcp

--- a/products/ai/grafana-mcp-server/templates/init-auth/bearer-auth-secret-init-job.yaml
+++ b/products/ai/grafana-mcp-server/templates/init-auth/bearer-auth-secret-init-job.yaml
@@ -22,6 +22,40 @@ spec:
             - sh
             - -c
             - |
-              kubectl get secret grafana-mcp-bearer-auth-secret -n {{ .Release.Namespace }} >/dev/null 2>&1 || \
-              kubectl create secret generic grafana-mcp-bearer-auth-secret -n {{ .Release.Namespace }} --from-literal=mcp-client="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+              set -eu
+
+              secret_name="grafana-mcp-bearer-auth-secret"
+              configured_clients="{{ join " " .Values.auth.clients }}"
+
+              if ! kubectl get secret "${secret_name}" -n {{ .Release.Namespace }} >/dev/null 2>&1; then
+                kubectl create secret generic "${secret_name}" -n {{ .Release.Namespace }}
+              fi
+
+              for client in ${configured_clients}; do
+                current_key="$(kubectl get secret "${secret_name}" -n {{ .Release.Namespace }} -o "jsonpath={.data.${client}}")"
+                if [ -z "${current_key}" ]; then
+                  generated_key="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+                  kubectl patch secret "${secret_name}" -n {{ .Release.Namespace }} --type merge \
+                    -p "{\"stringData\":{\"${client}\":\"${generated_key}\"}}"
+                fi
+              done
+
+              managed_clients="$(kubectl get secret "${secret_name}" -n {{ .Release.Namespace }} \
+                -o 'jsonpath={.metadata.annotations.homelab\.feddema\.dev/managed-clients}' 2>/dev/null || true)"
+              for client in $(printf '%s' "${managed_clients}" | tr ',' ' '); do
+                case " ${configured_clients} " in
+                  *" ${client} "*) ;;
+                  *)
+                    current_key="$(kubectl get secret "${secret_name}" -n {{ .Release.Namespace }} -o "jsonpath={.data.${client}}")"
+                    if [ -n "${current_key}" ]; then
+                      kubectl patch secret "${secret_name}" -n {{ .Release.Namespace }} --type json \
+                        -p "[{\"op\":\"remove\",\"path\":\"/data/${client}\"}]"
+                    fi
+                    ;;
+                esac
+              done
+
+              managed_clients="$(printf '%s' "${configured_clients}" | tr ' ' ',')"
+              kubectl annotate secret "${secret_name}" -n {{ .Release.Namespace }} --overwrite \
+                "homelab.feddema.dev/managed-clients=${managed_clients}"
 {{- end }}

--- a/products/ai/grafana-mcp-server/templates/init-auth/bearer-auth-secret-init-role.yaml
+++ b/products/ai/grafana-mcp-server/templates/init-auth/bearer-auth-secret-init-role.yaml
@@ -10,5 +10,5 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "patch"]
 {{- end }}

--- a/products/ai/grafana-mcp-server/values.yaml
+++ b/products/ai/grafana-mcp-server/values.yaml
@@ -2,6 +2,8 @@ apiKey: AgAWvSkInaFDh9tFwsfeRnQmpT5YAThveKO1B23+QD1Q9Gkf+q9QUl35hcuspx55HNVa6zV6
 
 auth:
   enabled: true
+  clients:
+    - mba-floris-devcontainer
   secretInit:
     image:
       repository: alpine/kubectl


### PR DESCRIPTION
The devcontainer included cluster tooling but lacked safe, usable authentication for the Argo CD CLI and Grafana MCP server. This enables both without exposing administrator credentials or granting write access.

- Run `argocd` in core mode against the mounted read-only Kubernetes credentials while retaining the direct API binary as `argocd-real`.
- Provision stable, per-user Grafana MCP API keys that Argo CD can reconcile and revoke.
- Generate Copilot CLI MCP configuration during the trusted-host credential bootstrap and expose it automatically inside the devcontainer.
- Document setup, rotation, and revocation behavior.

Grafana MCP remains server-side read-only, and Kubernetes RBAC continues to deny Argo CD write operations.