### PR TITLE
Harden descheduler policies and observability

### DIFF
--- a/products/core/descheduler/Chart.yaml
+++ b/products/core/descheduler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: descheduler
-version: 1.0.11
+version: 1.0.12
 
 dependencies:
   - name: descheduler

--- a/products/core/descheduler/dashboards/descheduler-dashboard.json
+++ b/products/core/descheduler/dashboards/descheduler-dashboard.json
@@ -1,0 +1,322 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(up{namespace=\"descheduler\",job=\"descheduler\"})",
+          "instant": true,
+          "legendFormat": "Descheduler",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller health",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "increase(kube_pod_container_status_restarts_total{namespace=\"descheduler\",container=\"descheduler\"}[$__range])",
+          "instant": true,
+          "legendFormat": "Restarts",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Container restarts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(descheduler_descheduler_loop_duration_seconds_count{namespace=\"descheduler\"}[15m])",
+          "legendFormat": "Completed cycles",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Policy cycle rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(descheduler_descheduler_loop_duration_seconds_bucket{namespace=\"descheduler\"}[15m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(descheduler_descheduler_loop_duration_seconds_bucket{namespace=\"descheduler\"}[15m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Policy cycle duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"descheduler\",container=\"descheduler\"} |= \"Number of evictions/requests\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Eviction cycle summaries",
+      "type": "logs"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "tags": [
+    "kubernetes",
+    "descheduler"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Kubernetes Descheduler",
+  "uid": "kubernetes-descheduler",
+  "version": 1
+}

--- a/products/core/descheduler/templates/alerts.yaml
+++ b/products/core/descheduler/templates/alerts.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: descheduler.rules
+spec:
+  groups:
+    - name: descheduler.rules
+      rules:
+        - alert: DeschedulerDown
+          expr: absent(up{namespace="descheduler",job="descheduler"}) or max(up{namespace="descheduler",job="descheduler"}) == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Descheduler metrics target is unavailable
+            description: Prometheus has been unable to scrape the descheduler for at least 10 minutes.
+        - alert: DeschedulerLoopStalled
+          expr: increase(descheduler_descheduler_loop_duration_seconds_count{namespace="descheduler"}[15m]) < 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Descheduler loop is stalled
+            description: The descheduler has not completed a policy cycle in the last 15 minutes.
+        - alert: DeschedulerLoopSlow
+          expr: histogram_quantile(0.99, sum by (le) (rate(descheduler_descheduler_loop_duration_seconds_bucket{namespace="descheduler"}[15m]))) > 60
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Descheduler policy cycles are slow
+            description: The descheduler p99 policy-cycle duration has exceeded 60 seconds for 15 minutes.
+        - alert: DeschedulerRestarting
+          expr: increase(kube_pod_container_status_restarts_total{namespace="descheduler",container="descheduler"}[15m]) > 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Descheduler is restarting repeatedly
+            description: The descheduler container restarted more than twice in the last 15 minutes.

--- a/products/core/descheduler/templates/grafana-dashboards.yaml
+++ b/products/core/descheduler/templates/grafana-dashboards.yaml
@@ -1,0 +1,13 @@
+{{- $files := .Files.Glob "dashboards/**.json" }}
+{{- range $path, $fileContents := $files }}
+{{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $dashboardName | trunc 63 | trimSuffix "-" }}
+  labels:
+    grafana_dashboard: "1"
+data:
+  {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
+{{- end }}

--- a/products/core/descheduler/values.yaml
+++ b/products/core/descheduler/values.yaml
@@ -1,6 +1,8 @@
 descheduler:
   kind: Deployment
   deschedulingInterval: 5m
+  cmdOptions:
+    dry-run: true
   resources:
     requests:
       cpu: 20m
@@ -17,51 +19,75 @@ descheduler:
 
   deschedulerPolicyAPIVersion: descheduler/v1alpha2
   deschedulerPolicy:
-    strategies: null
+    maxNoOfPodsToEvictPerNode: 2
+    maxNoOfPodsToEvictPerNamespace: 2
+    maxNoOfPodsToEvictTotal: 5
+    evictionFailureEventNotification: true
+    metricsProviders:
+      - source: KubernetesMetrics
     profiles:
-      - name: DefaultEvictor
-        nodeFit: true
-        evictLocalStoragePods: true
-        evictFailedBarePods: true
-      - name: RemovePodsHavingTooManyRestarts
-        args:
-          podRestartThreshold: 10
-          includingInitContainers: true
-      - name: LowNodeUtilization
-        args:
-          thresholds:
-            cpu : 20
-            memory: 20
-          targetThresholds:
-            cpu : 50
-            memory: 50
-          metricsUtilization:
-            metricsServer: true
-      - name: RemovePodsViolatingNodeAffinity
-        args:
-          nodeAffinityType:
-            - requiredDuringSchedulingIgnoredDuringExecution
-            - preferreddDuringSchedulingIgnoredDuringExecution
-      - name: RemovePodsViolatingInterPodAntiAffinity
-      - name: RemovePodsViolatingTopologySpreadConstraint
-        args:
-          topologyBalanceNodeFit: true
-          constraints:
-            - DoNotSchedule
-            - ScheduleAnyway
-      - name: RemovePodsViolatingNodeTaints
-        args:
-          includePreferNoSchedule: true
-          excludedTains:
-            - node.kubernetes.io/unschedulable
-    plugins:
-      deschedule:
-        enabled:
-          - RemovePodsHavingTooManyRestarts
-          - RemovePodsViolatingInterPodAntiAffinity
-          - RemovePodsViolatingNodeAffinity
-          - RemovePodsViolatingNodeTaints
-      balance:
-        enabled:
-          - LowNodeUtilization
-          - RemovePodsViolatingTopologySpreadConstraint
+      - name: default
+        pluginConfig:
+          - name: DefaultEvictor
+            args:
+              nodeFit: true
+              minPodAge: 10m
+              podProtections:
+                extraEnabled:
+                  - PodsWithPVC
+                  - PodsWithoutPDB
+          - name: RemovePodsHavingTooManyRestarts
+            args:
+              podRestartThreshold: 10
+              includingInitContainers: true
+          - name: RemoveFailedPods
+            args:
+              reasons:
+                - Evicted
+              excludeOwnerKinds:
+                - Job
+              minPodLifetimeSeconds: 3600
+              includingInitContainers: true
+          - name: RemoveDuplicates
+          - name: LowNodeUtilization
+            args:
+              thresholds:
+                cpu: 20
+                memory: 20
+                pods: 20
+              targetThresholds:
+                cpu: 50
+                memory: 50
+                pods: 50
+              metricsUtilization:
+                source: KubernetesMetrics
+          - name: RemovePodsViolatingNodeAffinity
+            args:
+              nodeAffinityType:
+                - requiredDuringSchedulingIgnoredDuringExecution
+                - preferredDuringSchedulingIgnoredDuringExecution
+          - name: RemovePodsViolatingInterPodAntiAffinity
+          - name: RemovePodsViolatingTopologySpreadConstraint
+            args:
+              topologyBalanceNodeFit: true
+              constraints:
+                - DoNotSchedule
+                - ScheduleAnyway
+          - name: RemovePodsViolatingNodeTaints
+            args:
+              includePreferNoSchedule: true
+              excludedTaints:
+                - node.kubernetes.io/unschedulable
+        plugins:
+          deschedule:
+            enabled:
+              - RemovePodsHavingTooManyRestarts
+              - RemoveFailedPods
+              - RemovePodsViolatingInterPodAntiAffinity
+              - RemovePodsViolatingNodeAffinity
+              - RemovePodsViolatingNodeTaints
+          balance:
+            enabled:
+              - RemoveDuplicates
+              - LowNodeUtilization
+              - RemovePodsViolatingTopologySpreadConstraint


### PR DESCRIPTION
The deployed descheduler policy was structured incorrectly, leaving its plugin configuration ineffective and allowing no bounded rollout path. This change repairs the policy and introduces conservative safeguards before real evictions are enabled.

- Defines a valid single profile with corrected affinity and taint options
- Caps evictions per node, namespace, and cycle
- Protects PVC-backed and PDB-less workloads and enforces a minimum pod age
- Adds `RemoveDuplicates` and conservative cleanup of old evicted, non-Job pods
- Configures Kubernetes Metrics access for utilization balancing
- Adds Grafana visibility and Prometheus alerts for controller health, cycle performance, restarts, and eviction summaries
- Enables dry-run mode so policy decisions can be observed before permitting evictions

The next rollout step is to observe dashboard and log output, then disable dry-run once the candidate evictions are confirmed safe.